### PR TITLE
Stop the Stopwatch properly

### DIFF
--- a/core/src/main/java/com/eternalcode/core/EternalCore.java
+++ b/core/src/main/java/com/eternalcode/core/EternalCore.java
@@ -475,7 +475,7 @@ public class EternalCore extends JavaPlugin implements EternalCoreApi {
         Metrics metrics = new Metrics(this, 13964);
         //metrics.addCustomChart(new SingleLineChart("users", () -> 0));
 
-        long millis = started.elapsed(TimeUnit.MILLISECONDS);
+        long millis = started.stop().elapsed(TimeUnit.MILLISECONDS);
         this.getLogger().info("Successfully loaded EternalCore in " + millis + "ms");
     }
 


### PR DESCRIPTION
## Description

Currently, the Stopwatch is only stopped on the VM stop/kill. This PR fixes it, and stops the running timer on the end of enabling.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added appropriate labels to this Pull Request

